### PR TITLE
Fixed bug where refreshing providers page would reset all profile providers

### DIFF
--- a/src/components/dashboard/providers/ProviderCard.js
+++ b/src/components/dashboard/providers/ProviderCard.js
@@ -10,7 +10,7 @@ export default class ProviderCard extends Component {
   constructor(props) {
     super(props);
 
-    this.state = { 
+    this.state = {
       detailsExpanded: false,
       healthRecordAccess: 'none'
     };
@@ -77,7 +77,7 @@ export default class ProviderCard extends Component {
             <div className="details-dates-added-on">
               <div className="date-key">Added on</div>
               <div className="date-value">{this.formatDate(this.props.provider.addedOn)}</div>
-            </div>          
+            </div>
             <div className="details-dates-last-updated">
               <div className="date-key">Last updated</div>
               <div className="date-value">{this.formatDate(this.props.provider.lastUpdated)}</div>
@@ -101,9 +101,9 @@ export default class ProviderCard extends Component {
   }
 
   render() {
-    return ( 
+    return (
       <div className="provider-card">
-        <div className="provider-card__titlebar" onClick={this.toggleDetails} onKeyPress={this.toggleDetails} 
+        <div className="provider-card__titlebar" onClick={this.toggleDetails} onKeyPress={this.toggleDetails}
           role="button" tabIndex={0}>
           <div className="provider-card__titlebar-name">
             {this.props.provider.name}

--- a/src/containers/dashboard/Providers.js
+++ b/src/containers/dashboard/Providers.js
@@ -8,7 +8,9 @@ import ProviderCard from '../../components/dashboard/providers/ProviderCard';
 
 export class Providers extends Component {
   componentWillMount() {
-    if (this.props.profile) this.props.loadProfileProviders(this.props.profile.id);
+    if (this.props.profileId) {
+      this.props.loadProfileProviders(this.props.profileId);
+    }
   }
 
   providersList = () => {
@@ -75,7 +77,7 @@ export class Providers extends Component {
 }
 
 Providers.propTypes = {
-  profile: PropTypes.object,
+  profileId: PropTypes.number,
   providers: PropTypes.array,
   profileProviders: PropTypes.array,
   linkProvider: PropTypes.func.isRequired,
@@ -91,7 +93,7 @@ function mapDispatchToProps(dispatch) {
 
 function mapStateToProps(state) {
   return {
-    profile: state.profiles.activeProfile,
+    profileId: state.profiles.activeProfileId,
     providers: state.providers.providers,
     profileProviders: state.providers.profileProviders
   };


### PR DESCRIPTION
The issue was because I was checking for an active profile instead of an active profile id, which is what persists on reload.